### PR TITLE
Harden deployment scripts

### DIFF
--- a/copy_to_move.sh
+++ b/copy_to_move.sh
@@ -4,14 +4,16 @@ echo "Killing control_surface_move process on Move..."
 ssh ableton@move.local killall control_surface_move
 echo "Copying build to Move..."
 scp  -r ./dist/* ableton@move.local:./
-ssh root@move.local cp -aL /data/UserData/control_surface_move/control_surface_move_shim.so /usr/lib/
-ssh root@move.local chmod u+s /usr/lib/control_surface_move_shim.so
+ssh root@move.local 'command cp -aL /data/UserData/control_surface_move/control_surface_move_shim.so /usr/lib/'
+ssh root@move.local 'command chmod u+s /usr/lib/control_surface_move_shim.so'
 if ssh root@move.local "test ! -f /opt/move/MoveOriginal"; then
-  ssh root@move.local mv /opt/move/Move /opt/move/MoveOriginal
+  ssh root@move.local 'command mv /opt/move/Move /opt/move/MoveOriginal'
 fi
 
-ssh root@move.local chmod +x /data/UserData/control_surface_move/Move.sh
-ssh root@move.local cp /data/UserData/control_surface_move/Move.sh /opt/move/Move
+ssh root@move.local 'command chmod +x /data/UserData/control_surface_move/Move.sh'
+ssh root@move.local 'command cp /data/UserData/control_surface_move/Move.sh /opt/move/Move'
+
+ssh ableton@move.local 'nohup /opt/move/MoveLauncher >/dev/null 2>&1 &' &
 
 # cp /data/UserData/control_surface_move/Move.sh /opt/move/Move
 # /etc/suid-debug

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -55,15 +55,15 @@ $ssh_ableton "tar -xvf ./$filename"
 
 $ssh_ableton "killall MoveLauncher Move MoveOriginal"
 
-$ssh_root cp -aL /data/UserData/control_surface_move/control_surface_move_shim.so /usr/lib/
-$ssh_root chmod u+s /usr/lib/control_surface_move_shim.so
+$ssh_root 'command cp -aL /data/UserData/control_surface_move/control_surface_move_shim.so /usr/lib/'
+$ssh_root 'command chmod u+s /usr/lib/control_surface_move_shim.so'
 if $ssh_root "test ! -f /opt/move/MoveOriginal"; then
-  $ssh_root mv /opt/move/Move /opt/move/MoveOriginal
-  $ssh_ableton cp /opt/move/MoveOriginal ~/
+  $ssh_root 'command mv /opt/move/Move /opt/move/MoveOriginal'
+  $ssh_ableton "command cp /opt/move/MoveOriginal ~/"
 fi
 
-$ssh_root chmod +x /data/UserData/control_surface_move/Move.sh
-$ssh_root cp /data/UserData/control_surface_move/Move.sh /opt/move/Move
+$ssh_root 'command chmod +x /data/UserData/control_surface_move/Move.sh'
+$ssh_root 'command cp /data/UserData/control_surface_move/Move.sh /opt/move/Move
 
 $ssh_root md5sum /opt/move/Move
 $ssh_root md5sum /opt/move/MoveOriginal
@@ -87,7 +87,7 @@ else
     echo "Not installing Pages of Sets"
 fi
 
-echo "Restating Move binary with shim installed..."
+echo "Restarting Move binary with shim installed..."
 
 
 $ssh_ableton "nohup /opt/move/MoveLauncher 2>/dev/null 1>/dev/null &" &


### PR DESCRIPTION
## Summary
  - wrap every privileged `cp/mv/chmod` in `command …` so aliases such as `cp='cp -i'` can’t stall automation
  - automatically restart `MoveLauncher` after `copy_to_move.sh` finishes

  ## Testing
  - `./copy_to_move.sh` (after the Docker rebuild) ⇒ completes without hanging and restarts MoveLauncher
  - `installer/install.sh` (local mode) ⇒ no interactive prompts when copying files
